### PR TITLE
Small fix to allow for list descriptions.

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -206,6 +206,11 @@ syn match org_timestamp_inactive /\(\[%%(diary-float.\+\]\)/
 hi def link org_timestamp PreProc
 hi def link org_timestamp_inactive Comment
 
+" Lists
+let s:listLeader = "^\\s*[\\+*-]\\s*"
+exec "syn match org_list_description /".s:listLeader."\\zs.\\{-}\\ze::/"
+hi def link org_list_description Identifier
+
 " Deadline/Schedule
 syn match org_deadline_scheduled /^\s*\(DEADLINE\|SCHEDULED\):/
 hi def link org_deadline_scheduled PreProc


### PR DESCRIPTION
See this for the original Emacs functionality:
http://orgmode.org/guide/Plain-lists.html#Plain-lists

There are three differences in the vim mode:
- We're not using a simple bold, but the Identifier syn hilight group. I
  think it's a more "Vimmy" way to use a predefined hi group.
- We're not highlighting the `::` — matter of taste, I think it adds
  clutter
- We're not matching only `::` (with spaces to the left and right,) but just `::` Again, a matter of
  taste; feel free to change that, jceb.
