### PR TITLE
Allow globbing in g:org_agenda_files

### DIFF
--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 import os
+import glob
 
 from orgmode import ORGMODE, settings
 from orgmode import get_bufnumber
@@ -77,8 +78,13 @@ class Agenda(object):
 				u"files to the agenda view."))
 			return
 
-		agenda_files = [os.path.realpath(os.path.expanduser(f))
-			for f in agenda_files]
+		resolved_files = []
+		for f in agenda_files:
+			f = glob.glob(os.path.join(os.path.expanduser(os.path.dirname(f)),
+				          os.path.basename(f)))
+			resolved_files.extend(f)
+
+		agenda_files = [os.path.realpath(f) for f in resolved_files]
 
 		for agenda_file in agenda_files: 
 			vim.command((u'badd %s' % agenda_file).encode(u'utf-8'))


### PR DESCRIPTION
Newly created files in an agenda dir are automatically picked up without editing vimrc
