### PR TITLE
Implement date selection functions

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -77,8 +77,11 @@ for p in vim.eval("&runtimepath").split(','):
 			sys.path.append(dname)
 			break
 
-from orgmode._vim import ORGMODE
+from orgmode._vim import ORGMODE, insert_at_cursor, get_user_input, date_to_str
 ORGMODE.start()
+
+from Date import Date
+import datetime
 EOF
 
 " ******************** Taglist/Tagbar integration ********************
@@ -102,3 +105,26 @@ endif
 " Pass parameters to taglist
 let g:tlist_org_settings = 'org;s:section;h:hyperlinks'
 let g:Tlist_Ctags_Cmd .= ' --options=' . expand('<sfile>:p:h') . '/org.cnf '
+
+" ******************** Calendar integration ********************
+fun CalendarAction(day, month, year, week, dir)
+	let g:org_timestamp = printf("%04d-%02d-%02d Fri", a:year, a:month, a:day)
+	let datetime_date = printf("datetime.date(%d, %d, %d)", a:year, a:month, a:day)
+	exe "py selected_date = " . datetime_date
+	" get_user_input
+	let msg = printf("Inserting %s | Modify date", g:org_timestamp)
+	exe "py modifier = get_user_input('" . msg . "')"
+	" change date according to user input
+	exe "py print modifier"
+	exe "py newdate = Date._modify_time(selected_date, modifier)"
+	exe "py newdate = date_to_str(newdate)"
+	" close Calendar
+	exe "q"
+	" goto previous window
+	exe "wincmd p"
+	exe "py timestamp = '" . g:org_timestamp_template . "' % newdate"
+	exe "py insert_at_cursor(timestamp)"
+	" restore calendar_action
+	let g:calendar_action = g:org_calendar_action_backup
+endf
+

--- a/ftplugin/orgmode/_vim.py
+++ b/ftplugin/orgmode/_vim.py
@@ -11,6 +11,7 @@ import imp
 import types
 
 import vim
+from datetime import datetime
 
 import orgmode.keybinding
 import orgmode.menu
@@ -240,6 +241,15 @@ def fold_orgmode(allow_dirty=False):
 		else:
 			vim.command((u'let b:fold_expr = %d' % heading.level).encode(u'utf-8'))
 
+
+def date_to_str(date):
+	if isinstance(date, datetime):
+		date = date.strftime(
+				u'%Y-%m-%d %a %H:%M'.encode(u'utf-8')).decode(u'utf-8')
+	else:
+		date = date.strftime(
+				u'%Y-%m-%d %a'.encode(u'utf-8')).decode(u'utf-8')
+	return date 
 
 class OrgMode(object):
 	u""" Vim Buffer """

--- a/ftplugin/orgmode/plugins/Date.py
+++ b/ftplugin/orgmode/plugins/Date.py
@@ -218,7 +218,7 @@ class Date(object):
 		"""
 		today = date.today()
 		msg = u''.join([u'Inserting ',
-				today.strftime(u'%Y-%m-%d %a'.encode(u'utf-8')),
+				unicode(today.strftime(u'%Y-%m-%d %a'), u'utf-8'),
 				u' | Modify date'])
 		modifier = get_user_input(msg)
 
@@ -239,6 +239,27 @@ class Date(object):
 
 		insert_at_cursor(timestamp)
 
+	@classmethod
+	def insert_timestamp_with_calendar(cls, active=True):
+		u"""
+		Insert a timestamp at the cursor position.
+		Show fancy calendar to pick the date from.
+
+		TODO: add all modifier of orgmode.
+		"""
+		if int(vim.eval(u'exists(":CalendarH")'.encode(u'utf-8'))) != 2:
+			vim.command("echo 'Please install plugin Calendar to enable this function'")
+			return
+		vim.command("CalendarH")
+		# backup calendar_action
+		calendar_action = vim.eval("g:calendar_action")
+		vim.command("let g:org_calendar_action_backup = '" + calendar_action + "'")
+		vim.command("let g:calendar_action = 'CalendarAction'")
+
+		timestamp_template = u'<%s>' if active else u'[%s]'
+		# timestamp template
+		vim.command("let g:org_timestamp_template = '" + timestamp_template + "'")
+
 	def register(self):
 		u"""
 		Registration of the plugin.
@@ -254,6 +275,16 @@ class Date(object):
 				Plug(u'OrgDateInsertTimestampInactive',
 					u':py ORGMODE.plugins[u"Date"].insert_timestamp(False)<CR>')))
 		self.menu + ActionEntry(u'Timestamp (&inactive)', self.keybindings[-1])
+
+		self.keybindings.append(Keybinding(u'<localleader>pa',
+				Plug(u'OrgDateInsertTimestampActiveWithCalendar',
+				u':py ORGMODE.plugins[u"Date"].insert_timestamp_with_calendar()<CR>')))
+		self.menu + ActionEntry(u'Timestamp with Calendar', self.keybindings[-1])
+
+		self.keybindings.append(Keybinding(u'<localleader>pi',
+				Plug(u'OrgDateInsertTimestampInactiveWithCalendar',
+					u':py ORGMODE.plugins[u"Date"].insert_timestamp_with_calendar(False)<CR>')))
+		self.menu + ActionEntry(u'Timestamp with Calendar(inactive)', self.keybindings[-1])
 
 		submenu = self.menu + Submenu(u'Change &Date')
 		submenu + ActionEntry(u'Day &Earlier', u'<C-x>', u'<C-x>')


### PR DESCRIPTION
- Fix insert timestamp failure problem for zh-tw 
  If your locale is zh-tw(or other double byte lang), the date encoding will fail since there is out of range (>127) characters.
- Integrate "calendar.vim" plugin to implement date picker function
  steps:
  1. Download calendar.vim first 
  2. Use GVim menu [Orgmode] -> [Dates and Scheduling] -> Timestamp with Calendar/ Timestamp with Calendar(inactive)
  3. Open calendar.vim on the buttom
  4. Select a date you want
  5. Prompt a reformat date string like original "Timestamp" function
  6. Insert date at the cursor

The hotkeys for Timestamp insertion with Calendar are <localleader>pa and <localleader>pi.
