### PR TITLE
Use new relative link syntax in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,4 +37,4 @@
   Information about the license are found in the file LICENSE.
 
 * Installation and Usage
-  Installation and usage instructions are found in the file [[vim-orgmode/blob/master/doc/orgguide.txt][doc/orgguide.txt]].
+  Installation and usage instructions are found in the file [[doc/orgguide.txt][doc/orgguide.txt]].


### PR DESCRIPTION
GitHub recently [changed how relative links in readmes work](https://help.github.com/articles/relative-links-in-readmes), and it broke the link to orgguide.txt. This patch fixes it (confirmed).
