### PR TITLE
Fix ValueError

### DIFF
--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -168,7 +168,7 @@ class Agenda(object):
 				# update last_date
 				last_date = h.active_date
 
-			bufname = os.path.basename(vim.buffers[h.document.bufnr - 1].name)
+			bufname = os.path.basename(vim.buffers[h.document.bufnr].name)
 			bufname = bufname[:-4] if bufname.endswith(u'.org') else bufname
 			formated = u"  %(bufname)s (%(bufnr)d)  %(todo)s  %(title)s" % {
 				'bufname': bufname,


### PR DESCRIPTION
Removing '-1' fixes the following error

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/ccc/home/gsaenger/.vim/bundle/vim-orgmode/ftplugin/orgmode/plugins/Agenda.py", line 171, in list_next_week
    bufname = os.path.basename(vim.buffers[h.document.bufnr - 1].name)
ValueError: number must be greater than zero