### PR TITLE
Fix error message when creating checkboxes

### DIFF
--- a/ftplugin/orgmode/plugins/EditCheckbox.py
+++ b/ftplugin/orgmode/plugins/EditCheckbox.py
@@ -113,7 +113,7 @@ class EditCheckbox(object):
 			start += 1
 		# vim's buffer behave just opposite to Python's list when inserting a
 		# new item.  The new entry is appended in vim put prepended in Python!
-		vim.current.buffer[start:start] = [unicode(nc)]
+		vim.current.buffer[start:start] = [str(unicode(nc))]
 
 		# update checkboxes status
 		cls.update_checkboxes_status()


### PR DESCRIPTION
Fix for https://github.com/jceb/vim-orgmode/issues/179 where and error message would be displayed when creating new checkboxes on some configurations.