### PR TITLE
[Syntax] Hyperlinks will now conceal the # (intern. links)

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -243,7 +243,7 @@ hi def link org_table_separator Type
 
 " Hyperlinks: {{{1
 syntax match hyperlink	"\[\{2}[^][]*\(\]\[[^][]*\)\?\]\{2}" contains=hyperlinkBracketsLeft,hyperlinkURL,hyperlinkBracketsRight containedin=ALL
-syntax match hyperlinkBracketsLeft	contained "\[\{2}"     conceal
+syntax match hyperlinkBracketsLeft	contained "\[\{2}#\?"     conceal
 syntax match hyperlinkURL				    contained "[^][]*\]\[" conceal
 syntax match hyperlinkBracketsRight	contained "\]\{2}"     conceal
 hi def link hyperlink Underlined


### PR DESCRIPTION
- For instance, internal links can have the following form:
  [[#LINK_NAME]] and [[#LINK_NAME][DESCRIPTION]].

  In the first case, #LINK_NAME was always displayed; but
  the # should be removed (concealed). This patch does that.