### PR TITLE
The vimscripts calendar.vim does *not* have :CalendarH. 

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -226,7 +226,7 @@ INSTALLATION AND UPGRADE                                 *orgguide-installation*
   are listed in the following section.
 
   Note: If you want to insert timestamp by using a calendar, you should
-  install calendar(http://www.vim.org/scripts/script.php?script_id=52) to
+  install calendar(https://github.com/mattn/calendar-vim) to
   enable this feature.
 
 ------------------------------------------------------------------------------
@@ -267,7 +267,7 @@ Suggested plugins~
     Easy management of multiple vim plugins.
 
   calendar~
-    (http://www.vim.org/scripts/script.php?script_id=52)
+    (https://github.com/mattn/calendar-vim)
     This plugin will create a calendar window for timestamp insertion.
 
   SyntaxRange~


### PR DESCRIPTION
You must use mattn/calendar-vim from GitHub.  Change orgguide.txt to reflect this.