### PR TITLE
Return to right window before setting todo.

### DIFF
--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -273,7 +273,7 @@ class Todo(object):
 							res += (u'\t' if res else u'') + u'[%s] %s' % (k, v)
 							# map access keys to callback that updates current heading
 							# map selection keys
-							vim.command((u'nnoremap <silent> <buffer> %s :bw<Bar>py ORGMODE.plugins[u"Todo"].set_todo_state("%s".decode(u"utf-8"))<CR>' % (k, v)).encode(u'utf-8'))
+							vim.command((u'nnoremap <silent> <buffer> %s :bw<CR><c-w><c-p>:py ORGMODE.plugins[u"Todo"].set_todo_state("%s".decode(u"utf-8"))<CR>' % (k, v)).encode(u'utf-8'))
 						elif v:
 							res += (u'\t' if res else u'') + v
 			if res:


### PR DESCRIPTION
With things like NERDTree open, the interactive todo jumps back to the wrong window and therefore doesn't work.  This goes back to the correct window (previous one) before doing the TODO change.