### PR TITLE
added support for org-beamer-export-to-pdf

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -171,6 +171,7 @@ via the 'Org' menu. Most are only usable in command mode.
 
   Export:~
     <localleader>ep     - export as PDF
+    <localleader>eb     - export as Beamer PDF
     <localleader>eh     - export as HTML
     <localleader>el     - export as LaTeX
 
@@ -1067,6 +1068,7 @@ Currently, the export to pdf, html, latex and markdown is supported via the
 following commands and the 'export' menu:
 >
   :OrgExportToPDF
+  :OrgExportToBeamerPDF
   :OrgExportToHTML
   :OrgExportToLaTeX
   :OrgExportToMarkdown

--- a/ftplugin/orgmode/plugins/Export.py
+++ b/ftplugin/orgmode/plugins/Export.py
@@ -90,6 +90,15 @@ class Export(object):
 			echom(u'Export successful: %s.%s' % (vim.eval(u'expand("%:r")'), 'pdf'))
 
 	@classmethod
+	def tobeamer(cls):
+		u"""Export the current buffer as beamer pdf using emacs orgmode."""
+		ret = cls._export(u'org-beamer-export-to-pdf')
+		if ret != 0:
+			echoe(u'PDF export failed.')
+		else:
+			echom(u'Export successful: %s.%s' % (vim.eval(u'expand("%:r")'), 'pdf'))
+
+	@classmethod
 	def tohtml(cls):
 		u"""Export the current buffer as html using emacs orgmode."""
 		ret = cls._export(u'org-html-export-to-html')
@@ -133,6 +142,14 @@ class Export(object):
 			function=u':py ORGMODE.plugins[u"Export"].topdf()<CR>',
 			key_mapping=u'<localleader>ep',
 			menu_desrc=u'To PDF (via Emacs)'
+		)
+		# to Beamer PDF
+		add_cmd_mapping_menu(
+			self,
+			name=u'OrgExportToBeamerPDF',
+			function=u':py ORGMODE.plugins[u"Export"].tobeamer()<CR>',
+			key_mapping=u'<localleader>eb',
+			menu_desrc=u'To Beamer PDF (via Emacs)'
 		)
 		# to latex
 		add_cmd_mapping_menu(


### PR DESCRIPTION
This adds functionality to export PDF as 'beamer'-class
Added:
 - `<localleader>eb`
 - `:OrgExportToBeamerPDF`
 - Documentation for said changes

Not added: `org-beamer-export-as-latex` since I didn't want to change too much and I'm not "fluent" in python