### PR TITLE
Checkbox issue#209

### DIFF
--- a/ftplugin/orgmode/liborgmode/checkboxes.py
+++ b/ftplugin/orgmode/liborgmode/checkboxes.py
@@ -276,6 +276,12 @@ class Checkbox(DomObj):
 		raise StopIteration()
 
 	def all_children_status(self):
+		u""" Return checkboxes status for currnet checkbox's all children
+
+		:return: (total, on)
+			total: total # of checkboxes
+			on:	   # of checkboxes which are on
+		"""
 		total, on = 0, 0
 		for c in self.all_children():
 			if c.status is not None:

--- a/ftplugin/orgmode/liborgmode/checkboxes.py
+++ b/ftplugin/orgmode/liborgmode/checkboxes.py
@@ -275,6 +275,17 @@ class Checkbox(DomObj):
 
 		raise StopIteration()
 
+	def all_children_status(self):
+		total, on = 0, 0
+		for c in self.all_children():
+			if c.status is not None:
+				total += 1
+
+				if c.status == Checkbox.STATUS_ON:
+					on += 1
+
+		return (total, on)
+
 	def all_siblings_status(self):
 		u""" Return checkboxes status for currnet checkbox's all siblings
 

--- a/ftplugin/orgmode/plugins/EditCheckbox.py
+++ b/ftplugin/orgmode/plugins/EditCheckbox.py
@@ -145,7 +145,7 @@ class EditCheckbox(object):
 
 		if c.status == Checkbox.STATUS_OFF or c.status is None:
 			# set checkbox status on if all children are on
-			if not c.children or c.are_children_all(Checkbox.STATUS_ON):
+			if c.all_children_status()[0] == 0 or c.are_children_all(Checkbox.STATUS_ON):
 				c.toggle()
 				d.write_checkbox(c)
 			elif c.status is None:
@@ -153,7 +153,7 @@ class EditCheckbox(object):
 				d.write_checkbox(c)
 
 		elif c.status == Checkbox.STATUS_ON:
-			if not c.children or c.is_child_one(Checkbox.STATUS_OFF):
+			if c.all_children_status()[0] == 0 or c.is_child_one(Checkbox.STATUS_OFF):
 				c.toggle()
 				d.write_checkbox(c)
 
@@ -213,7 +213,7 @@ class EditCheckbox(object):
 		for c in checkbox.all_siblings():
 			current_status = c.status
 			# if this checkbox is not leaf, its status should determine by all its children
-			if c.children:
+			if c.all_children_status()[0] > 0:
 				current_status = cls._update_checkboxes_status(c.first_child)
 
 			# don't update status if the checkbox has no status
@@ -239,7 +239,9 @@ class EditCheckbox(object):
 
 		parent_status = Checkbox.STATUS_INT
 		# all silbing checkboxes are off status
-		if status_off == total:
+		if total == 0:
+			pass
+		elif status_off == total:
 			parent_status = Checkbox.STATUS_OFF
 		# all silbing checkboxes are on status
 		elif status_on == total:


### PR DESCRIPTION
Fixed issue #209 by requiring at least one child checkbox to have non-`None` status for the subtree of a checkbox to be considered a checkbox list rather than plain list.