### PR TITLE
Neovim current.buffer[last_line] `out of bound` issue #213

### DIFF
--- a/ftplugin/orgmode/plugins/EditCheckbox.py
+++ b/ftplugin/orgmode/plugins/EditCheckbox.py
@@ -113,7 +113,9 @@ class EditCheckbox(object):
 			start += 1
 		# vim's buffer behave just opposite to Python's list when inserting a
 		# new item.  The new entry is appended in vim put prepended in Python!
+		vim.current.buffer.append("")
 		vim.current.buffer[start:start] = [unicode(nc)]
+		del vim.current.buffer[-1]
 
 		# update checkboxes status
 		cls.update_checkboxes_status()

--- a/ftplugin/orgmode/plugins/EditCheckbox.py
+++ b/ftplugin/orgmode/plugins/EditCheckbox.py
@@ -113,9 +113,9 @@ class EditCheckbox(object):
 			start += 1
 		# vim's buffer behave just opposite to Python's list when inserting a
 		# new item.  The new entry is appended in vim put prepended in Python!
-		vim.current.buffer.append("")
+		vim.current.buffer.append("") # workaround for neovim
 		vim.current.buffer[start:start] = [unicode(nc)]
-		del vim.current.buffer[-1]
+		del vim.current.buffer[-1] # restore from workaround for neovim
 
 		# update checkboxes status
 		cls.update_checkboxes_status()

--- a/ftplugin/orgmode/vimbuffer.py
+++ b/ftplugin/orgmode/vimbuffer.py
@@ -175,7 +175,7 @@ class VimBuffer(Document):
 		# update changed headings and add new headings
 		for h in self.all_headings():
 			if h.is_dirty:
-				vim.current.buffer.append("")
+				vim.current.buffer.append("") # workaround for neovim bug
 				if h._orig_start is not None:
 					# this is a heading that existed before and was changed. It
 					# needs to be replaced
@@ -186,7 +186,7 @@ class VimBuffer(Document):
 				else:
 					# this is a new heading. It needs to be inserted
 					self._content[h.start:h.start] = [unicode(h)] + h.body
-				vim.current.buffer[-1]
+				del vim.current.buffer[-1] # restore workaround for neovim bug
 				h._dirty_heading = False
 				h._dirty_body = False
 			# for all headings the length and start offset needs to be updated

--- a/ftplugin/orgmode/vimbuffer.py
+++ b/ftplugin/orgmode/vimbuffer.py
@@ -175,6 +175,7 @@ class VimBuffer(Document):
 		# update changed headings and add new headings
 		for h in self.all_headings():
 			if h.is_dirty:
+				vim.current.buffer.append("")
 				if h._orig_start is not None:
 					# this is a heading that existed before and was changed. It
 					# needs to be replaced
@@ -185,6 +186,7 @@ class VimBuffer(Document):
 				else:
 					# this is a new heading. It needs to be inserted
 					self._content[h.start:h.start] = [unicode(h)] + h.body
+				vim.current.buffer[-1]
 				h._dirty_heading = False
 				h._dirty_body = False
 			# for all headings the length and start offset needs to be updated


### PR DESCRIPTION
A fix for issue #213. Actually I don't like how it looks. But I don't know how to solve it more elegantly. We should probably delete this fix once neovim fixed its issue.