### PR TITLE
Handling UTF-8 characters on stftime

### DIFF
--- a/ftplugin/orgmode/liborgmode/orgdate.py
+++ b/ftplugin/orgmode/liborgmode/orgdate.py
@@ -186,6 +186,9 @@ class OrgDate(datetime.date):
 	def __str__(self):
 		return self.__unicode__().encode(u'utf-8')
 
+	def strftime(self, fmt):
+		return datetime.date.strftime(self, fmt.encode(u'utf-8')).decode(u'utf-8')
+
 
 class OrgDateTime(datetime.datetime):
 	u"""
@@ -214,6 +217,9 @@ class OrgDateTime(datetime.datetime):
 
 	def __str__(self):
 		return self.__unicode__().encode(u'utf-8')
+
+	def strftime(self, fmt):
+		return datetime.datetime.strftime(self, fmt.encode(u'utf-8')).decode(u'utf-8')
 
 
 class OrgTimeRange(object):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -8,6 +8,7 @@ import test_libcheckbox
 import test_libbase
 import test_libheading
 import test_liborgdate
+import test_liborgdate_utf8
 import test_liborgdate_parsing
 import test_liborgdatetime
 import test_liborgtimerange
@@ -36,6 +37,7 @@ if __name__ == '__main__':
 	tests.addTests(test_libagendafilter.suite())
 	tests.addTests(test_libheading.suite())
 	tests.addTests(test_liborgdate.suite())
+	tests.addTests(test_liborgdate_utf8.suite())
 	tests.addTests(test_liborgdate_parsing.suite())
 	tests.addTests(test_liborgdatetime.suite())
 	tests.addTests(test_liborgtimerange.suite())

--- a/tests/test_liborgdate_utf8.py
+++ b/tests/test_liborgdate_utf8.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import unittest
+import locale
+import threading
+
+from datetime import date
+from contextlib import contextmanager
+
+sys.path.append(u'../ftplugin')
+from orgmode.liborgmode.orgdate import OrgDate
+
+class OrgDateUtf8TestCase(unittest.TestCase):
+	u"""
+	Tests OrgDate with utf-8 enabled locales
+	"""
+	LOCALE_LOCK = threading.Lock()
+	UTF8_LOCALE = "pt_BR.utf-8"
+
+	@contextmanager
+	def setlocale(self, name):
+		with self.LOCALE_LOCK:
+			saved = locale.setlocale(locale.LC_ALL)
+			try:
+				yield locale.setlocale(locale.LC_ALL, name)
+			finally:
+				locale.setlocale(locale.LC_ALL, saved)
+
+	def setUp(self):
+		self.year = 2016
+		self.month = 5
+		self.day = 7
+		self.text = u'<2016-05-07 Sáb>'
+		self.textinactive = u'[2016-05-07 Sáb]'
+
+	def test_OrdDate_str_unicode_active(self):
+		with self.setlocale(self.UTF8_LOCALE):
+			od = OrgDate(True, self.year, self.month, self.day)
+			self.assertEqual(self.text, unicode(od))
+
+	def test_OrdDate_str_unicode_inactive(self):
+		with self.setlocale(self.UTF8_LOCALE):
+			od = OrgDate(False, self.year, self.month, self.day)
+			self.assertEqual(self.textinactive, unicode(od))
+
+def suite():
+	return unittest.TestLoader().loadTestsFromTestCase(OrgDateUtf8TestCase)
+
+# vi: noexpandtab


### PR DESCRIPTION
This fixes errors raised when opening the week agenda view and dates include UTF-8 characters like **á**

Probably first lines of python ever written by me, so excuse any gross misuses of best-practices