### PR TITLE
Using \k instead of \a when matching dates

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -229,28 +229,29 @@ unlet! s:todo_headings
 
 " Timestamps: {{{1
 "<2003-09-16 Tue>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a>\)/
+"<2003-09-16 Sáb>
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k>\)/
 "<2003-09-16 Tue 12:00>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>\)/
 "<2003-09-16 Tue 12:00-12:30>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d-\d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d-\d\d:\d\d>\)/
 
 "<2003-09-16 Tue>--<2003-09-16 Tue>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a>--<\d\d\d\d-\d\d-\d\d \a\a\a>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k>--<\d\d\d\d-\d\d-\d\d \k\k\k>\)/
 "<2003-09-16 Tue 12:00>--<2003-09-16 Tue 12:00>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>--<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>--<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>\)/
 
 syn match org_timestamp /\(<%%(diary-float.\+>\)/
 
 "[2003-09-16 Tue]
-syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \a\a\a\]\)/
+syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \k\k\k\]\)/
 "[2003-09-16 Tue 12:00]
-syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]\)/
+syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d\]\)/
 
 "[2003-09-16 Tue]--[2003-09-16 Tue]
-syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \a\a\a\]--\[\d\d\d\d-\d\d-\d\d \a\a\a\]\)/
+syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \k\k\k\]--\[\d\d\d\d-\d\d-\d\d \k\k\k\]\)/
 "[2003-09-16 Tue 12:00]--[2003-09-16 Tue 12:00]
-syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]--\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]\)/
+syn match org_timestamp_inactive /\(\[\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d\]--\[\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d\]\)/
 
 syn match org_timestamp_inactive /\(\[%%(diary-float.\+\]\)/
 

--- a/syntax/orgagenda.vim
+++ b/syntax/orgagenda.vim
@@ -52,15 +52,15 @@ unlet! s:todo_headings
 
 " Timestamps
 "<2003-09-16 Tue>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k>\)/
 "<2003-09-16 Tue 12:00>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>\)/
 "<2003-09-16 Tue 12:00-12:30>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d-\d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d-\d\d:\d\d>\)/
 "<2003-09-16 Tue>--<2003-09-16 Tue>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a>--<\d\d\d\d-\d\d-\d\d \a\a\a>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k>--<\d\d\d\d-\d\d-\d\d \k\k\k>\)/
 "<2003-09-16 Tue 12:00>--<2003-09-16 Tue 12:00>
-syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>--<\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d>\)/
+syn match org_timestamp /\(<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>--<\d\d\d\d-\d\d-\d\d \k\k\k \d\d:\d\d>\)/
 syn match org_timestamp /\(<%%(diary-float.\+>\)/
 hi def link org_timestamp PreProc
 


### PR DESCRIPTION
Vim's \a does not match accented alphabet characters like á. With \k both the
accented version and the regular one are matched.
For help with \k please refer to iskeyword

With this change, dates like <2016-05-07 Sáb> are highlighted properly