### PR TITLE
Matching dates with UTF-8 characters

### DIFF
--- a/ftplugin/orgmode/liborgmode/orgdate.py
+++ b/ftplugin/orgmode/liborgmode/orgdate.py
@@ -25,32 +25,32 @@ import datetime
 import re
 
 # <2011-09-12 Mon>
-_DATE_REGEX = re.compile(r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>")
+_DATE_REGEX = re.compile(r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>", re.UNICODE)
 # [2011-09-12 Mon]
-_DATE_PASSIVE_REGEX = re.compile(r"\[(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w\]")
+_DATE_PASSIVE_REGEX = re.compile(r"\[(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w\]", re.UNICODE)
 
 # <2011-09-12 Mon 10:20>
 _DATETIME_REGEX = re.compile(
-	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d{1,2}):(\d\d)>")
+	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d{1,2}):(\d\d)>", re.UNICODE)
 # [2011-09-12 Mon 10:20]
 _DATETIME_PASSIVE_REGEX = re.compile(
-	r"\[(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d{1,2}):(\d\d)\]")
+	r"\[(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d{1,2}):(\d\d)\]", re.UNICODE)
 
 # <2011-09-12 Mon>--<2011-09-13 Tue>
 _DATERANGE_REGEX = re.compile(
 	# <2011-09-12 Mon>--
 	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>--"
 	# <2011-09-13 Tue>
-	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>")
+	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>", re.UNICODE)
 # <2011-09-12 Mon 10:00>--<2011-09-12 Mon 11:00>
 _DATETIMERANGE_REGEX = re.compile(
 	# <2011-09-12 Mon 10:00>--
 	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>--"
 	# <2011-09-12 Mon 11:00>
-	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>")
+	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>", re.UNICODE)
 # <2011-09-12 Mon 10:00--12:00>
 _DATETIMERANGE_SAME_DAY_REGEX = re.compile(
-	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)-(\d\d):(\d\d)>")
+	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)-(\d\d):(\d\d)>", re.UNICODE)
 
 
 def get_orgdate(data):

--- a/tests/test_liborgdate_parsing.py
+++ b/tests/test_liborgdate_parsing.py
@@ -24,7 +24,7 @@ class OrgDateParsingTestCase(unittest.TestCase):
 
 	def test_get_orgdate_parsing_active(self):
 		u"""
-		get_orgdate should recognice all orgdates in a given text
+		get_orgdate should recognize all orgdates in a given text
 		"""
 		result = get_orgdate(self.text)
 		self.assertNotEqual(result, None)
@@ -38,9 +38,10 @@ class OrgDateParsingTestCase(unittest.TestCase):
 		datestr = u"This date <2011-08-30 Tue> is embedded"
 		self.assertTrue(isinstance(get_orgdate(datestr), OrgDate))
 
+
 	def test_get_orgdatetime_parsing_active(self):
 		u"""
-		get_orgdate should recognice all orgdatetimess in a given text
+		get_orgdate should recognize all orgdatetimes in a given text
 		"""
 		result = get_orgdate(u"<2011-09-12 Mon 10:20>")
 		self.assertNotEqual(result, None)
@@ -55,9 +56,10 @@ class OrgDateParsingTestCase(unittest.TestCase):
 		result = get_orgdate(u"some datetime <2011-09-12 Mon 10:20> stuff")
 		self.assertTrue(isinstance(result, OrgDateTime))
 
+
 	def test_get_orgtimerange_parsing_active(self):
 		u"""
-		get_orgdate should recognice all orgtimeranges in a given text
+		get_orgdate should recognize all orgtimeranges in a given text
 		"""
 		daterangestr = u"<2011-09-12 Mon>--<2011-09-13 Tue>"
 		result = get_orgdate(daterangestr)
@@ -82,7 +84,7 @@ class OrgDateParsingTestCase(unittest.TestCase):
 
 	def test_get_orgdate_parsing_inactive(self):
 		u"""
-		get_orgdate should recognice all inactive orgdates in a given text
+		get_orgdate should recognize all inactive orgdates in a given text
 		"""
 		result = get_orgdate(self.textinactive)
 		self.assertNotEqual(result, None)
@@ -98,7 +100,7 @@ class OrgDateParsingTestCase(unittest.TestCase):
 
 	def test_get_orgdatetime_parsing_passive(self):
 		u"""
-		get_orgdate should recognice all orgdatetimess in a given text
+		get_orgdate should recognize all orgdatetimes in a given text
 		"""
 		result = get_orgdate(u"[2011-09-12 Mon 10:20]")
 		self.assertNotEqual(result, None)
@@ -192,6 +194,51 @@ class OrgDateParsingTestCase(unittest.TestCase):
 
 		datestr = u"<2012-03-40 Tue 24:70>"
 		self.assertEqual(get_orgdate(datestr), None)
+
+	def test_get_orgdate_parsing_with_utf8(self):
+		u"""
+		get_orgdate should recognize all orgdates within a given utf-8 text
+		"""
+		result = get_orgdate(u'<2016-05-07 Sáb>')
+		self.assertNotEqual(result, None)
+		self.assertTrue(isinstance(result, OrgDate))
+		self.assertEqual(result.year, 2016)
+		self.assertEqual(result.month, 5)
+		self.assertEqual(result.day, 7)
+		self.assertTrue(result.active)
+
+		datestr = u"This date <2016-05-07 Sáb> is embedded"
+		self.assertTrue(isinstance(get_orgdate(datestr), OrgDate))
+
+		result = get_orgdate(u'[2016-05-07 Sáb]')
+		self.assertFalse(result.active)
+
+		datestr = u"This date [2016-05-07 Sáb] is embedded"
+		self.assertTrue(isinstance(get_orgdate(datestr), OrgDate))
+
+	def test_get_orgdatetime_parsing_with_utf8(self):
+		u"""
+		get_orgdate should recognize all orgdatetimes in a given utf-8 text
+		"""
+		result = get_orgdate(u"<2016-05-07 Sáb 10:20>")
+		self.assertNotEqual(result, None)
+		self.assertTrue(isinstance(result, OrgDateTime))
+		self.assertEqual(result.year, 2016)
+		self.assertEqual(result.month, 5)
+		self.assertEqual(result.day, 7)
+		self.assertEqual(result.hour, 10)
+		self.assertEqual(result.minute, 20)
+		self.assertTrue(result.active)
+
+		result = get_orgdate(u"some datetime <2016-05-07 Sáb 10:20> stuff")
+		self.assertTrue(isinstance(result, OrgDateTime))
+
+		result = get_orgdate(u"[2016-05-07 Sáb 10:20]")
+		self.assertFalse(result.active)
+
+		result = get_orgdate(u"some datetime [2016-05-07 Sáb 10:20] stuff")
+		self.assertTrue(isinstance(result, OrgDateTime))
+
 
 
 def suite():


### PR DESCRIPTION
Without the re.UNICODE option the patterns do not match dates with accented
characters like "Sáb", that can be generated depending on the user's locale