### PR TITLE
Don't force Keyword to upper case

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -24,6 +24,7 @@
 *** Deprecated
     - Nothing
 *** Removed
+    - Removed the requirement for TODO state keywords to be upper-case.
 *** Fixed
     - Fix non-English locale support issue in OrgDate and Agenda. (merges #234,
       closes #230)

--- a/ftplugin/orgmode/liborgmode/headings.py
+++ b/ftplugin/orgmode/liborgmode/headings.py
@@ -592,8 +592,7 @@ class Heading(DomObj):
 	level = property(**level())
 
 	def todo():
-		u""" Todo state of current heading. When todo state is set, it will be
-		converted to uppercase """
+		u""" Todo state of current heading. When todo state is set"""
 		def fget(self):
 			# extract todo state from heading
 			return self._todo
@@ -610,9 +609,6 @@ class Heading(DomObj):
 				v = value
 				if type(v) == str:
 					v = u_decode(v)
-				# TODO think if you want to fix this i.e. german 'ß'.upper()
-				# is converted to SS and that is by the rules... cf.
-				# https://bugs.python.org/issue4610
 				self._todo = v
 			self.set_dirty_heading()
 

--- a/ftplugin/orgmode/liborgmode/headings.py
+++ b/ftplugin/orgmode/liborgmode/headings.py
@@ -613,7 +613,7 @@ class Heading(DomObj):
 				# TODO think if you want to fix this i.e. german 'ß'.upper()
 				# is converted to SS and that is by the rules... cf.
 				# https://bugs.python.org/issue4610
-				self._todo = v.upper()
+				self._todo = v
 			self.set_dirty_heading()
 
 		def fdel(self):

--- a/tests/test_vimbuffer.py
+++ b/tests/test_vimbuffer.py
@@ -1198,7 +1198,7 @@ Bla Bla bla bla
 		self.assertEqual(self.document.headings[3].todo, u'DÖNE')
 		self.assertEqual(self.document.headings[3].title, u'Überschrift 4')
 
-		#self.assertEqual(self.document.headings[4].todo, u'DONSS')
+		self.assertEqual(self.document.headings[4].todo, u'DONß')
 		self.assertEqual(self.document.headings[4].title, u'Überschrift 5')
 
 		self.assertEqual(self.document.headings[5].todo, u'DONÉ')

--- a/tests/test_vimbuffer.py
+++ b/tests/test_vimbuffer.py
@@ -1223,21 +1223,21 @@ Bla Bla bla bla
 		self.assertEqual(d.headings[0].title, u'Überschrift 1')
 		self.assertEqual(unicode(d.headings[0]), u'* Überschrift 1							    :testtag:')
 
-	def test_todo_write_todo_lowercase(self):
-		self.assertEqual(self.document.headings[0].todo, u'TODO')
-		self.document.headings[0].todo = u'waiting'
-		self.assertEqual(self.document.headings[0].is_dirty_body, False)
-		self.assertEqual(self.document.headings[0].is_dirty_heading, True)
-		self.assertEqual(self.document.headings[0].todo, u'WAITING')
-		self.assertEqual(self.document.headings[0].title, u'Überschrift 1')
-		self.assertEqual(unicode(self.document.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
-		self.assertEqual(self.document.write(), True)
-
-		# sanity check
-		d = VimBuffer().init_dom()
-		self.assertEqual(d.headings[0].todo, u'WAITING')
-		self.assertEqual(d.headings[0].title, u'Überschrift 1')
-		self.assertEqual(unicode(d.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
+#	def test_todo_write_todo_lowercase(self):
+#		self.assertEqual(self.document.headings[0].todo, u'TODO')
+#		self.document.headings[0].todo = u'waiting'
+#		self.assertEqual(self.document.headings[0].is_dirty_body, False)
+#		self.assertEqual(self.document.headings[0].is_dirty_heading, True)
+#		self.assertEqual(self.document.headings[0].todo, u'WAITING')
+#		self.assertEqual(self.document.headings[0].title, u'Überschrift 1')
+#		self.assertEqual(unicode(self.document.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
+#		self.assertEqual(self.document.write(), True)
+#
+#		# sanity check
+#		d = VimBuffer().init_dom()
+#		self.assertEqual(d.headings[0].todo, u'WAITING')
+#		self.assertEqual(d.headings[0].title, u'Überschrift 1')
+#		self.assertEqual(unicode(d.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
 
 	def test_todo_write_todo_uppercase(self):
 		self.assertEqual(self.document.headings[0].todo, u'TODO')

--- a/tests/test_vimbuffer.py
+++ b/tests/test_vimbuffer.py
@@ -1223,22 +1223,6 @@ Bla Bla bla bla
 		self.assertEqual(d.headings[0].title, u'Überschrift 1')
 		self.assertEqual(unicode(d.headings[0]), u'* Überschrift 1							    :testtag:')
 
-#	def test_todo_write_todo_lowercase(self):
-#		self.assertEqual(self.document.headings[0].todo, u'TODO')
-#		self.document.headings[0].todo = u'waiting'
-#		self.assertEqual(self.document.headings[0].is_dirty_body, False)
-#		self.assertEqual(self.document.headings[0].is_dirty_heading, True)
-#		self.assertEqual(self.document.headings[0].todo, u'WAITING')
-#		self.assertEqual(self.document.headings[0].title, u'Überschrift 1')
-#		self.assertEqual(unicode(self.document.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
-#		self.assertEqual(self.document.write(), True)
-#
-#		# sanity check
-#		d = VimBuffer().init_dom()
-#		self.assertEqual(d.headings[0].todo, u'WAITING')
-#		self.assertEqual(d.headings[0].title, u'Überschrift 1')
-#		self.assertEqual(unicode(d.headings[0]), u'* WAITING Überschrift 1						    :testtag:')
-
 	def test_todo_write_todo_uppercase(self):
 		self.assertEqual(self.document.headings[0].todo, u'TODO')
 		self.document.headings[0].todo = u'DONE'


### PR DESCRIPTION
There are several reasons for this.

* I don't see the point of forcing recognized keyword to be upper case in the
  first place.
* Syntax highlighting & keyword recognition will be according to user defined
  keyword list. If user defined lower-case keyword, those keywords will not be
  properly highlighted or recognized after being forcefully uppercased. It's
  hampering user experience.
* Judging from test, it seems the intension of forceful uppercase conversion is
  designed to change user inputted lower-case keyword to upper case. It's
  poorly designed, because the lower case input won't be recognized as keyword
  in the first place. Hence the `upper()` function was actually never take any
  effect. But even if it functions as it should. Say, user defined a keyword in
  UPPER case, and typing in a lower cased version of that word, most likely
  they just want them to be non-keyword. I don't want my orgmode to recognizing
  each header I have with `Waiting` as its first word of the sentence to lose
  that word as a keyword.
* for letters like `ß`, not all `toupper` converter behave as standard
  indicate. In this particular case, using `python2` or `vim`'s built-in
  `toupper()` will obtain `ß`. Using `python3` will obtain `SS` as standard
  indicate.

All in all, the strange forcefully upper-case converting behavior is not
necessary, experience hampering and buggy in more ways than one. Hence I think
why not just get rid of it.
