### PR TITLE
Plain-list alignment issue after promotion of header

### DIFF
--- a/ftplugin/orgmode/_vim.py
+++ b/ftplugin/orgmode/_vim.py
@@ -182,7 +182,6 @@ def indent_orgmode():
 		checkbox = heading.current_checkbox()
 		level = heading.level + 1
 		if checkbox:
-			level = level + checkbox.number_of_parents * 6
 			if line != checkbox.start_vim:
 				# indent body up to the beginning of the checkbox' text
 				# if checkbox isn't indented to the proper location, the body


### PR DESCRIPTION
Hi!

I ran into an issue when promoting a header if it contains a plain list (with or without checkboxes). While trying to figure out the cause, I found a way to fix it, but I'm not sure if this is the proper way to fix it, so please reject this PR if it's not :). The issue is as follows. Say I have the following org file:

    * Header 1
    ** Header 2
       - item 1
       - item 2
       - item 3
       - item 4
       - item 5
       - item 6

Now, if I promote _Header 2_ using `<<`, I get the following file:

    * Header 1
    * Header 2
      - item 1
      - item 2
      - item 3
            - item 4
            - item 5
            - item 6

Depending on the number of items, the result will be different.

I used git bisect to find the commit where this behaviour started. I found that prior to commit 0baf1792d7de805b19e67f0b094926a988c9ca6f, it worked fine. After this commit, things started behaving erratically, but in a different way than described above. The current behaviour started in commit 176bc344591b964c9f59ca2c957c3cf55d190c68.

The behaviour described by the commit message of the latter commit ("indent checkboxes relative to their parents") still seems to work after my change: if the list is not properly aligned with its header, it will be aligned after a promotion or demotion. But I'm new to org, so there may be some corner cases I'm not aware of.

I hope this helps. Let me know if you need more information.