### PR TITLE
Add hint in doc for "not fully implemented" feature

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -716,6 +716,7 @@ Priorities~
 
 ------------------------------------------------------------------------------
 Breaking tasks down into subtasks~
+  Not fully implemented in vim-orgmode~
 
 It is often advisable to break down large tasks into smaller, manageable
 subtasks. You can do this by creating an outline tree below a TODO item,


### PR DESCRIPTION
Add hint to doc because the fraction feature (`[/]` or `[%]`) does not work with task status (e.g. `TODO`/`DONE`) yet.
