### PR TITLE
Update orgguide.txt

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -139,7 +139,7 @@ via the 'Org' menu. Most are only usable in command mode.
       <ar             - promote subtree
 
   Hyperlinks:~
-    gl              - goto link
+    gl              - goto link (vim builin gx would work too)
     gyl             - yank link
     gil             - insert new link
 


### PR DESCRIPTION
Hi there, 
I happened to find that the builtin command 'gx' more convenient to open url and binary files than 'gl'. Otherwise I would need to config 'g:utl_cfg_hdl_scm_http' first, which is not so friendly to a vim newbie. 
And 'gl' is wonderful to open local text files, as to create new file, which gx cannot operate in this way.

Thus I made a little change to document, just for your consideration. Thanks to your contribution so we can enjoy orgmode in vim :+1: :smile: 