### PR TITLE
Decode subprocess output

### DIFF
--- a/ftplugin/orgmode/plugins/Export.py
+++ b/ftplugin/orgmode/plugins/Export.py
@@ -81,7 +81,9 @@ class Export(object):
 		p.wait()
 
 		if p.returncode != 0 or settings.get(u'org_export_verbose') == 1:
-			echom('\n'.join(p.communicate()))
+			echom('\n'.join(map(
+				lambda x: x.decode('utf-8'),
+				p.communicate())))
 		return p.returncode
 
 	@classmethod


### PR DESCRIPTION
When export fails the output should be messaged to the user. This
however did not work on Python 3 because the result of p.communicate()
is a tuple of bytes and join() expects strings. This lead to the error:

    TypeError: sequence item 0: expected str instance, bytes found