### PR TITLE
Fix all the invalid escape sequences.

### DIFF
--- a/ftplugin/orgmode/liborgmode/orgdate.py
+++ b/ftplugin/orgmode/liborgmode/orgdate.py
@@ -43,13 +43,13 @@ _DATERANGE_REGEX = re.compile(
 	# <2011-09-12 Mon>--
 	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>--"
 	# <2011-09-13 Tue>
-	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>", re.UNICODE)
+	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w>", re.UNICODE)
 # <2011-09-12 Mon 10:00>--<2011-09-12 Mon 11:00>
 _DATETIMERANGE_REGEX = re.compile(
 	# <2011-09-12 Mon 10:00>--
 	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>--"
 	# <2011-09-12 Mon 11:00>
-	"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>", re.UNICODE)
+	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)>", re.UNICODE)
 # <2011-09-12 Mon 10:00--12:00>
 _DATETIMERANGE_SAME_DAY_REGEX = re.compile(
 	r"<(\d\d\d\d)-(\d\d)-(\d\d) [A-Z]\w\w (\d\d):(\d\d)-(\d\d):(\d\d)>", re.UNICODE)

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -96,7 +96,7 @@ class Agenda(object):
 
 		# load the agenda files into buffers
 		for agenda_file in agenda_files:
-			vim.command(u_encode(u'badd %s' % agenda_file.replace(" ", "\ ")))
+			vim.command(u_encode(u'badd %s' % agenda_file.replace(" ", "\\ ")))
 
 		# determine the buffer nr of the agenda files
 		agenda_nums = [get_bufnumber(fn) for fn in agenda_files]

--- a/ftplugin/orgmode/plugins/Date.py
+++ b/ftplugin/orgmode/plugins/Date.py
@@ -78,7 +78,7 @@ class Date(object):
 			newdate = date(int(year), int(month), int(day))
 
 		# check abbreviated date, seperated with '-'
-		date_regex = u"(\d{1,2})-(\d+)-(\d+)"
+		date_regex = u"(\\d{1,2})-(\\d+)-(\\d+)"
 		match = re.search(date_regex, modifier)
 		if match:
 			year, month, day = match.groups()
@@ -86,7 +86,7 @@ class Date(object):
 
 		# check abbreviated date, seperated with '/'
 		# month/day
-		date_regex = u"(\d{1,2})/(\d{1,2})"
+		date_regex = u"(\\d{1,2})/(\\d{1,2})"
 		match = re.search(date_regex, modifier)
 		if match:
 			month, day = match.groups()
@@ -98,7 +98,7 @@ class Date(object):
 		# check full date, seperated with 'space'
 		# month day year
 		# 'sep 12 9' --> 2009 9 12
-		date_regex = u"(\w\w\w) (\d{1,2}) (\d{1,2})"
+		date_regex = u"(\\w\\w\\w) (\\d{1,2}) (\\d{1,2})"
 		match = re.search(date_regex, modifier)
 		if match:
 			gr = match.groups()
@@ -108,7 +108,7 @@ class Date(object):
 			newdate = date(year, int(month), int(day))
 
 		# check days as integers
-		date_regex = u"^(\d{1,2})$"
+		date_regex = u"^(\\d{1,2})$"
 		match = re.search(date_regex, modifier)
 		if match:
 			newday, = match.groups()
@@ -135,13 +135,13 @@ class Date(object):
 			newdate = startdate + timedelta(days=diff)
 
 		# check for days modifier with appended d
-		match = re.search(u'^(\+|-)(\d*)d', modifier)
+		match = re.search(u'^(\\+|-)(\\d*)d', modifier)
 		if match:
 			op, days = match.groups()
 			newdate = ops[op](startdate, timedelta(days=int(days)))
 
 		# check for days modifier without appended d
-		match = re.search(u'^(\+|-)(\d*) |^(\+|-)(\d*)$', modifier)
+		match = re.search(u'^(\\+|-)(\\d*) |^(\\+|-)(\\d*)$', modifier)
 		if match:
 			groups = match.groups()
 			try:
@@ -153,20 +153,20 @@ class Date(object):
 			newdate = ops[op](startdate, timedelta(days=days))
 
 		# check for week modifier
-		match = re.search(u'^(\+|-)(\d+)w', modifier)
+		match = re.search(u'^(\\+|-)(\\d+)w', modifier)
 		if match:
 			op, weeks = match.groups()
 			newdate = ops[op](startdate, timedelta(weeks=int(weeks)))
 
 		# check for month modifier
-		match = re.search(u'^(\+|-)(\d+)m', modifier)
+		match = re.search(u'^(\\+|-)(\\d+)m', modifier)
 		if match:
 			op, months = match.groups()
 			newdate = date(startdate.year, ops[op](startdate.month, int(months)),
 					startdate.day)
 
 		# check for year modifier
-		match = re.search(u'^(\+|-)(\d*)y', modifier)
+		match = re.search(u'^(\\+|-)(\\d*)y', modifier)
 		if match:
 			op, years = match.groups()
 			newdate = date(ops[op](startdate.year, int(years)), startdate.month,
@@ -174,7 +174,7 @@ class Date(object):
 
 		# check for month day
 		match = re.search(
-			u'(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) (\d{1,2})',
+			u'(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) (\\d{1,2})',
 			modifier.lower())
 		if match:
 			month = cls.month_mapping[match.groups()[0]]
@@ -186,7 +186,7 @@ class Date(object):
 
 		# check abbreviated date, seperated with '/'
 		# month/day/year
-		date_regex = u"(\d{1,2})/(\d+)/(\d+)"
+		date_regex = u"(\\d{1,2})/(\\d+)/(\\d+)"
 		match = re.search(date_regex, modifier)
 		if match:
 			month, day, year = match.groups()
@@ -195,7 +195,7 @@ class Date(object):
 		# check for month day year
 		# sep 12 2011
 		match = re.search(
-			u'(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) (\d{1,2}) (\d{1,4})',
+			u'(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) (\\d{1,2}) (\\d{1,4})',
 			modifier.lower())
 		if match:
 			month = int(cls.month_mapping[match.groups()[0]])
@@ -208,7 +208,7 @@ class Date(object):
 
 		# check for time: HH:MM
 		# '12:45' --> datetime(2006, 06, 13, 12, 45))
-		match = re.search(u'(\d{1,2}):(\d\d)$', modifier)
+		match = re.search(u'(\\d{1,2}):(\\d\\d)$', modifier)
 		if match:
 			try:
 				startdate = newdate

--- a/ftplugin/orgmode/plugins/EditStructure.py
+++ b/ftplugin/orgmode/plugins/EditStructure.py
@@ -140,7 +140,7 @@ class EditStructure(object):
 			# keys instead of making keys up like this
 			if level > 0:
 				if insert_mode:
-					vim.eval(u_encode(u'feedkeys("\<C-t>", "n")'))
+					vim.eval(u_encode(u'feedkeys("\\<C-t>", "n")'))
 				elif including_children:
 					vim.eval(u_encode(u'feedkeys(">]]", "n")'))
 				elif on_heading:
@@ -149,7 +149,7 @@ class EditStructure(object):
 					vim.eval(u_encode(u'feedkeys(">}", "n")'))
 			else:
 				if insert_mode:
-					vim.eval(u_encode(u'feedkeys("\<C-d>", "n")'))
+					vim.eval(u_encode(u'feedkeys("\\<C-d>", "n")'))
 				elif including_children:
 					vim.eval(u_encode(u'feedkeys("<]]", "n")'))
 				elif on_heading:

--- a/ftplugin/orgmode/plugins/Hyperlinks.py
+++ b/ftplugin/orgmode/plugins/Hyperlinks.py
@@ -130,7 +130,7 @@ class Hyperlinks(object):
 
 		# character escaping
 		uri = uri.replace(u'\\', u'\\\\\\\\')
-		uri = uri.replace(u' ', u'\ ')
+		uri = uri.replace(u' ', u'\\ ')
 
 		if description is None:
 			description = u_decode(vim.eval(u'input("Description: ")'))
@@ -191,7 +191,7 @@ class Hyperlinks(object):
 		# find next link
 		cmd = Command(
 			u'OrgHyperlinkNextLink',
-			u":if search('\[\{2}\zs[^][]*\(\]\[[^][]*\)\?\ze\]\{2}', 's') == 0 | echo 'No further link found.' | endif")
+			u":if search('\\[\\{2}\\zs[^][]*\\(\\]\\[[^][]*\\)\\?\\ze\\]\\{2}', 's') == 0 | echo 'No further link found.' | endif")
 		self.commands.append(cmd)
 		self.keybindings.append(
 			Keybinding(u'gn', Plug(u'OrgHyperlinkNextLink', self.commands[-1])))
@@ -200,7 +200,7 @@ class Hyperlinks(object):
 		# find previous link
 		cmd = Command(
 			u'OrgHyperlinkPreviousLink',
-			u":if search('\[\{2}\zs[^][]*\(\]\[[^][]*\)\?\ze\]\{2}', 'bs') == 0 | echo 'No further link found.' | endif")
+			u":if search('\\[\\{2}\\zs[^][]*\\(\\]\\[[^][]*\\)\\?\\ze\\]\\{2}', 'bs') == 0 | echo 'No further link found.' | endif")
 		self.commands.append(cmd)
 		self.keybindings.append(
 			Keybinding(u'go', Plug(u'OrgHyperlinkPreviousLink', self.commands[-1])))

--- a/ftplugin/orgmode/plugins/TagsProperties.py
+++ b/ftplugin/orgmode/plugins/TagsProperties.py
@@ -122,7 +122,7 @@ class TagsProperties(object):
 				for t2 in tags:
 					if t1 == t2:
 						continue
-					searchstring += u'\\(:[a-zA-Z:]*\\)\?:%s' % t2
+					searchstring += u'\\(:[a-zA-Z:]*\\)\\?:%s' % t2
 			searchstring += u'\\)'
 
 			vim.command(u'/\\zs:%s:\\ze' % searchstring)


### PR DESCRIPTION
Closes: #290.

It'd likely also be great if you ran your tests with `PYTHONWARNINGS=default`, to ensure no future ones are introduced, it's easy to make the mistake when the warnings are being hidden. You might also consider using a test runner rather than what you have in `run_tests`. I didn't make either of those changes, but if you're up for them I can possibly send a follow up PR.