### PR TITLE
fix ctrl-c on calendar insert message causing uncaught exception

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -163,7 +163,7 @@ fun CalendarAction(day, month, year, week, dir)
 	" goto previous window
 	exe "wincmd p"
 	exe s:py_version . "timestamp = '" . g:org_timestamp_template . "' % newdate"
-	exe s:py_version . "insert_at_cursor(timestamp)"
+	exe s:py_version . "if modifier != None: insert_at_cursor(timestamp)"
 	" restore calendar_action
 	let g:calendar_action = g:org_calendar_action_backup
 endf

--- a/ftplugin/orgmode/_vim.py
+++ b/ftplugin/orgmode/_vim.py
@@ -138,10 +138,10 @@ def get_user_input(message):
 	u"""Print the message and take input from the user.
 	Return the input or None if there is no input.
 	"""
-	vim.command(u_encode(u'call inputsave()'))
-	vim.command(u_encode(u"let user_input = input('" + message + u": ')"))
-	vim.command(u_encode(u'call inputrestore()'))
 	try:
+		vim.command(u_encode(u'call inputsave()'))
+		vim.command(u_encode(u"let user_input = input('" + message + u": ')"))
+		vim.command(u_encode(u'call inputrestore()'))
 		return u_decode(vim.eval(u_encode(u'user_input')))
 	except:
 		return None


### PR DESCRIPTION
I noticed that if I hit ctrl-c in the calendar picker, after getting the prompt to modify the date, I get an uncaught exception (See the gif).

before:
![calendar-exception(1)](https://user-images.githubusercontent.com/14203288/56142003-def9d380-5fd8-11e9-98a5-4b003bd92c83.gif)

after:
![after](https://user-images.githubusercontent.com/14203288/56173290-fe6c1d00-6027-11e9-91e3-19110fac1b34.gif)

I changed the code to catch the exception and return None.

Thank you.