### PR TITLE
Fix hardcoded Fri in calendar date picker

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -149,12 +149,11 @@ endif
 
 " * Calendar.vim {{{2
 fun CalendarAction(day, month, year, week, dir)
-	let g:org_timestamp = printf("%04d-%02d-%02d Fri", a:year, a:month, a:day)
-	let datetime_date = printf("datetime.date(%d, %d, %d)", a:year, a:month, a:day)
-	exe s:py_version . "selected_date = " . datetime_date
+	exe s:py_version . "selected_date = " . printf("datetime.date(%d, %d, %d)", a:year, a:month, a:day)
+	exe s:py_version . "org_timestamp = '" . g:org_timestamp_template . "' % date_to_str(selected_date)"
+
 	" get_user_input
-	let msg = printf("Inserting %s | Modify date", g:org_timestamp)
-	exe s:py_version . "modifier = get_user_input('" . msg . "')"
+	exe s:py_version . "modifier = get_user_input(org_timestamp)"
 	" change date according to user input
 	exe s:py_version . "newdate = Date._modify_time(selected_date, modifier)"
 	exe s:py_version . "newdate = date_to_str(newdate)"


### PR DESCRIPTION
I noticed that the day "Fri" is hardcoded into the function CalendarAction in org.vim.
I changed it so that it instead puts the actual day there
Before (notice I select a wednesday but it says Fri):
![before](https://user-images.githubusercontent.com/14203288/56143153-ffc32880-5fda-11e9-928b-b5646475ee53.gif)

After:
![after](https://user-images.githubusercontent.com/14203288/56143182-0782cd00-5fdb-11e9-9435-ceac895d43df.gif)

Thanks!