### PR TITLE
Replace non-ASCII chars with their numeric value in highlight group names

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -209,17 +209,18 @@ if !exists('g:loaded_org_syntax')
 			endif
 			" strip access key
 			let l:_i = substitute(l:i, "\(.*$", "", "")
+			let l:safename = substitute(l:_i, "\\W", "\\=('u' . char2nr(submatch(0)))", "g")
 
 			let l:group = l:default_group
 			for l:j in g:org_todo_keyword_faces
 				if l:j[0] == l:_i
-					let l:group = 'org_todo_keyword_face_' . l:_i
+					let l:group = 'org_todo_keyword_face_' . l:safename
 					call OrgExtendHighlightingGroup(l:default_group, l:group, OrgInterpretFaces(l:j[1]))
 					break
 				endif
 			endfor
-			silent! exec 'syntax match org_todo_keyword_' . l:_i . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings
-			silent! exec 'hi def link org_todo_keyword_' . l:_i . ' ' . l:group
+			silent! exec 'syntax match org_todo_keyword_' . l:safename . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings
+			silent! exec 'hi def link org_todo_keyword_' . l:safename . ' ' . l:group
 		endfor
 	endfunction
 endif


### PR DESCRIPTION
tl;dr

replaces any char matching `\W` to `"u" . char2nr(_matched_char_)` when calling `highlight`
which allows for decorated unicode todo keywords

------------



When defining a face for todo keyword, the `highlight` command is used internally with the new keyword as a part of the new name.

For example, when we want 'TODO' to be yellow we might define
```
let g:org_todo_keyword_faces = [['TODO', ':foreground yellow']]
```

For the above command `vim-orgmode` calls
```
highlight org_todo_keyword_face_TODO term=standout ctermfg=0 ctermbg=6 guifg=Blue guibg=Yellow  ctermfg=yellow guifg=yellow
```

If we were to define a new keyword that contains non-ASCII characters, `vim-orgmode` would try to use this non-ASCII word as a part of the highlight group name.

With these keywords and faces:
```
let g:org_todo_keywords = [['TODO', '할것', '|', '🐑'], ['|', 'CANCELED', '🦊']]
let g:org_todo_keyword_faces = [
    \['TODO', [':foreground yellow']],
    \['할것', [':foreground green', 'background yellow']],
    \['🐑', [':background LightCyan']],
    \['CANCELED', [':foreground red', ':background black', ':weight bold', ':slant italic', ':decoration underline']],
    \['🦊', [':foreground red', ':background black', ':weight bold', ':slant italic', ':decoration underline']]
\]
```

vim reports this error 3 times:
```
Error detected while processing function <SNR>29_ReadTodoKeywords[4]..<SNR>29_ReadTodoKeywords[20]..OrgExtendHighlightingGroup:
```

Internally `vim-orgmode` tried to run
```
highlight org_todo_keyword_face_TODO term=standout ctermfg=0 ctermbg=6 guifg=Blue guibg=Yellow  ctermfg=yellow guifg=yellow
highlight org_todo_keyword_face_할것 term=standout ctermfg=0 ctermbg=6 guifg=Blue guibg=Yellow  ctermfg=green guifg=green ctermfg=green guifg=green
highlight org_todo_keyword_face_🐑 term=standout ctermfg=2 gui=bold guifg=Green ctermbg=LightCyan guibg=LightCyan
highlight org_todo_keyword_face_CANCELED term=standout ctermfg=2 gui=bold guifg=Green ctermfg=red guifg=red ctermbg=black guibg=black term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
highlight org_todo_keyword_face_🦊 term=standout ctermfg=2 gui=bold guifg=Green ctermfg=red guifg=red ctermbg=black guibg=black term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
```

What this commit introduces is a conversion from all `\W` to their
`"u" . char2nr()` representation.

When this patch is applied the above highlight commands will change to:
```
highlight org_todo_keyword_face_TODO term=standout ctermfg=0 ctermbg=6 guifg=Blue guibg=Yellow  ctermfg=yellow guifg=yellow
highlight org_todo_keyword_face_u54624u44163 term=standout ctermfg=0 ctermbg=6 guifg=Blue guibg=Yellow  ctermfg=green guifg=green ctermfg=green guifg=green
highlight org_todo_keyword_face_u128017 term=standout ctermfg=2 gui=bold guifg=Green  ctermbg=LightCyan guibg=LightCyan
highlight org_todo_keyword_face_CANCELED term=standout ctermfg=2 gui=bold guifg=Green  ctermfg=red guifg=red ctermbg=black guibg=black term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
highlight org_todo_keyword_face_u129418 term=standout ctermfg=2 gui=bold guifg=Green  ctermfg=red guifg=red ctermbg=black guibg=black term=bold,italic,underline cterm=bold,italic,underline gui=bold,italic,underline
```

and errors will disappear