### PR TITLE
Add missing quotation mark in orgguide.txt

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -978,7 +978,7 @@ Agenda files~
 
   You can change the list of agenda files like this:
 >
-    let g:org_agenda_files = ['~/org/index.org', ~/org/project.org']
+    let g:org_agenda_files = ['~/org/index.org', '~/org/project.org']
 <
 
   Also globbing is allowed. This makes it easy to use ALL *.org files in a


### PR DESCRIPTION
While following orgguide.txt, I found there's a missing quotation mark in org_agenda_files.

I can't find a contribution guide so if I missing some progress please tell me.