### PR TITLE
Fix name of org_tags_column variable in guide

### DIFF
--- a/doc/orgguide.txt
+++ b/doc/orgguide.txt
@@ -805,7 +805,7 @@ Setting tags~
                         will either offer completion or a special single-key
                         interface for setting tags, see below.  After pressing
                         <CR>, the tags will be inserted and aligned to
-                        'org-tags-column'.
+                        'org_tags_column'.
 
                                                       *orgguide-<LocalLeader>ft*
   <LocalLeader>ft       Find tags in the current file.


### PR DESCRIPTION
As far as I can tell, the variable is called `org_tags_column`.