### PR TITLE
Feature: Exclude 'todo' keywords from spellcheck

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -219,7 +219,7 @@ if !exists('g:loaded_org_syntax')
 					break
 				endif
 			endfor
-			silent! exec 'syntax match org_todo_keyword_' . l:safename . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings
+			silent! exec 'syntax match org_todo_keyword_' . l:safename . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings . ' contains=@NoSpell'
 			silent! exec 'hi def link org_todo_keyword_' . l:safename . ' ' . l:group
 		endfor
 	endfunction

--- a/syntax/orgtodo.vim
+++ b/syntax/orgtodo.vim
@@ -37,7 +37,7 @@ if !exists('g:loaded_orgtodo_syntax')
 					break
 				endif
 			endfor
-			silent! exec 'syntax match orgtodo_todo_keyword_' . l:_i . ' /' . l:_i .'/ ' . a:todo_headings
+			silent! exec 'syntax match orgtodo_todo_keyword_' . l:_i . ' /' . l:_i .'/ ' . a:todo_headings . ' contains=@NoSpell'
 			silent! exec 'hi def link orgtodo_todo_keyword_' . l:_i . ' ' . l:group
 		endfor
 	endfunction


### PR DESCRIPTION
The configured 'org_todo_keywords' are subject to spellcheck. In
languages other than English, the spellchecker may not consider those
words to be spelled correctly. As a result, the spellchecker incorrectly
and annoyingly flags these words as misspelled. This patch removes the
keywords in the 'org_todo_keywords' from the province of the
spellchecker.

Issue #333 