### PR TITLE
Two improvements

### DIFF
--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -261,7 +261,7 @@ class Agenda(object):
         # format text of agenda
         final_agenda = []
         for i, h in enumerate(raw_agenda):
-            tmp = u"%s %s" % (h.todo, h.title)
+            tmp = fmt.format('{} {}', h.todo, h.title)
             final_agenda.append(tmp)
             cls.line2doc[len(final_agenda)] = (get_bufname(h.document.bufnr), h.document.bufnr, h.start)
 

--- a/ftplugin/orgmode/plugins/Agenda.py
+++ b/ftplugin/orgmode/plugins/Agenda.py
@@ -261,7 +261,7 @@ class Agenda(object):
         # format text of agenda
         final_agenda = []
         for i, h in enumerate(raw_agenda):
-            tmp = fmt.format('{} {}', h.todo, h.title)
+            tmp = fmt.format('{} {}', h.todo, h.title).lstrip().rstrip()
             final_agenda.append(tmp)
             cls.line2doc[len(final_agenda)] = (get_bufname(h.document.bufnr), h.document.bufnr, h.start)
 

--- a/ftplugin/orgmode/py3compat/py_py3_string.py
+++ b/ftplugin/orgmode/py3compat/py_py3_string.py
@@ -1,6 +1,17 @@
 import sys
+from string import Formatter
+
 
 if sys.version_info < (3,):
     VIM_PY_CALL = u':py'
 else:
     VIM_PY_CALL = u':py3'
+
+
+class NoneAsEmptyFormatter(Formatter):
+    def get_value(self, key, args, kwargs):
+        v = super().get_value(key, args, kwargs)
+        return '' if v is None else v
+
+
+fmt = NoneAsEmptyFormatter()

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -15,7 +15,6 @@ endif
 " *bold*, /italic/, _underline_, +strike-through+, =code=, ~verbatim~
 " Note:
 " - /italic/ is rendered as reverse in most terms (works fine in gVim, though)
-" - +strike-through+ doesn't work on Vim / gVim
 " - the non-standard `code' markup is also supported
 " - =code= and ~verbatim~ are also supported as block-level markup, see below.
 " Ref: http://orgmode.org/manual/Emphasis-and-monospace.html
@@ -32,6 +31,7 @@ if (s:conceal_aggressively == 1)
    syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|\(^\|[^\\]\)\@<==\S\@="        end="[^ \\]\zs=\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs=\|[^\\]\zs=\S\@="     concealends oneline
    syntax region org_code      matchgroup=org_border_code start="[^ \\]\zs`\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs`\|\(^\|[^\\]\)\@<=`\S\@="        end="[^ \\]\zs'\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs'\|[^\\]\zs'\S\@="     concealends oneline
    syntax region org_verbatim  matchgroup=org_border_verb start="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|\(^\|[^\\]\)\@<=\~\S\@="     end="[^ \\]\zs\~\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs\~\|[^\\]\zs\~\S\@="  concealends oneline
+   syntax region org_strikethrough  matchgroup=org_border_strike start="[^ \\]\zs+\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs+\|\(^\|[^\\]\)\@<=+\S\@="     end="[^ \\]\zs+\|\(\(^\|[^\\]\)\zs\(\\\\\)\+\)\zs+\|[^\\]\zs+\S\@="  concealends oneline
 else
     syntax region org_bold      start="\S\zs\*\|\*\S\@="     end="\S\zs\*\|\*\S\@="  keepend oneline
     syntax region org_italic    start="\S\zs\/\|\/\S\@="     end="\S\zs\/\|\/\S\@="  keepend oneline
@@ -39,11 +39,13 @@ else
     syntax region org_code      start="\S\zs=\|=\S\@="       end="\S\zs=\|=\S\@="    keepend oneline
     syntax region org_code      start="\S\zs`\|`\S\@="       end="\S\zs'\|'\S\@="    keepend oneline
     syntax region org_verbatim  start="\S\zs\~\|\~\S\@="     end="\S\zs\~\|\~\S\@="  keepend oneline
+    syntax region org_strikethrough  start="\S\zs+\|+\S\@="     end="\S\zs+\|+\S\@="  keepend oneline
 endif
 
 hi def org_bold      term=bold      cterm=bold      gui=bold
 hi def org_italic    term=italic    cterm=italic    gui=italic
 hi def org_underline term=underline cterm=underline gui=underline
+hi def org_strikethrough term=strikethrough cterm=strikethrough gui=strikethrough
 
 if (s:conceal_aggressively == 1)
     hi link org_border_bold org_bold


### PR DESCRIPTION
# 1. Gracefully format `None` in the view "Time line for the current buffer"

*Issue*: If items in a file don't have `TODO`, `DONE`, etc keywords, that is, have a form `<date> title`, like `tl1` below:

```
* <2022-02-21 Mon> tl1
* TODO <2022-02-22 Tue> tl3
```

.. then they appear with `None` in the view "Time line for the current buffer":

```
None <2022-02-21 Mon> tl1
TODO <2022-02-22 Tue> tl3
```

*Solution*: this commit removes these `None`s:

```
 <2022-02-21 Mon> tl1
TODO <2022-02-22 Tue> tl3
```

# 2. Add `strike-through` markup, 
gVim now supports it