### PR TITLE
Add the conventional b:current_syntax guards and assignment to our syntax/*.vim files.

### DIFF
--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -1,3 +1,7 @@
+if exists("b:current_syntax")
+    finish
+endif
+
 " Support org authoring markup as closely as possible
 " (we're adding two markdown-like variants for =code= and blockquotes)
 " -----------------------------------------------------------------------------
@@ -392,4 +396,5 @@ if exists('g:loaded_SyntaxRange')
   call SyntaxRange#Include('\$[^$]', '\$', 'tex')
 endif
 
+let b:current_syntax = "org"
 " vi: ft=vim:tw=80:sw=4:ts=4:fdm=marker

--- a/syntax/orgagenda.vim
+++ b/syntax/orgagenda.vim
@@ -2,6 +2,10 @@
 "      - Most of the stuff here is also in syntax.org
 "      - DRY!
 
+if exists("b:current_syntax")
+    finish
+endif
+
 syn match org_todo_key /\[\zs[^]]*\ze\]/
 hi def link org_todo_key Identifier
 
@@ -89,3 +93,5 @@ syntax match hyperlinkBracketsLeft		contained "\[\{2}" conceal
 syntax match hyperlinkURL				contained "[^][]*\]\[" conceal
 syntax match hyperlinkBracketsRight		contained "\]\{2}" conceal
 hi def link hyperlink Underlined
+
+let b:current_syntax = "orgagenda"

--- a/syntax/orgtodo.vim
+++ b/syntax/orgtodo.vim
@@ -1,3 +1,7 @@
+if exists("b:current_syntax")
+    finish
+endif
+
 syn match org_todo_key /\[\zs[^]]*\ze\]/
 hi def link org_todo_key Identifier
 
@@ -45,3 +49,5 @@ endif
 
 call s:ReadTodoKeywords(g:org_todo_keywords, s:todo_headings)
 unlet! s:todo_headings
+
+let b:current_syntax = "orgtodo"


### PR DESCRIPTION
This prevents the syntax/org.vim included in Vim v9.1.0865 from taking effect alongside vim-orgmode's org.vim.

(Addresses #394)